### PR TITLE
Add Serbian as a common pluralizations file

### DIFF
--- a/lib/rails_i18n/common_pluralizations/serbian.rb
+++ b/lib/rails_i18n/common_pluralizations/serbian.rb
@@ -1,0 +1,33 @@
+module RailsI18n
+    module Pluralization
+      module Serbian
+        FROM_2_TO_4   = (2..4).to_a.freeze
+        FROM_12_TO_14 = (12..14).to_a.freeze
+  
+        def self.rule
+          lambda do |n|
+            n ||= 0
+            mod10 = n % 10
+            mod100 = n % 100
+  
+            if mod10 == 1 && mod100 != 11
+              :one
+            elsif FROM_2_TO_4.include?(mod10) && !FROM_12_TO_14.include?(mod100)
+              :few
+            else
+              :other
+            end
+          end
+        end
+
+        def self.with_locale(locale)
+            { locale => {
+                :i18n => {
+                  :plural => {
+                    :keys => [:one, :few, :other],
+                    :rule => rule }}}}
+        end
+      end
+    end
+  end
+  

--- a/rails/pluralization/sr.rb
+++ b/rails/pluralization/sr.rb
@@ -1,30 +1,3 @@
-module RailsI18n
-  module Pluralization
-    module Serbian
-      FROM_2_TO_4   = (2..4).to_a.freeze
-      FROM_12_TO_14 = (12..14).to_a.freeze
+require 'rails_i18n/common_pluralizations/serbian'
 
-      def self.rule
-        lambda do |n|
-          n ||= 0
-          mod10 = n % 10
-          mod100 = n % 100
-
-          if mod10 == 1 && mod100 != 11
-            :one
-          elsif FROM_2_TO_4.include?(mod10) && !FROM_12_TO_14.include?(mod100)
-            :few
-          else
-            :other
-          end
-        end
-      end
-    end
-  end
-end
-
-{ :sr => {
-  :i18n => {
-    :plural => {
-      :keys => [:one, :few, :other],
-      :rule => RailsI18n::Pluralization::Serbian.rule }}}}
+::RailsI18n::Pluralization::Serbian.with_locale(:sr)


### PR DESCRIPTION
There's a bug in upstream Rails i18n, https://github.com/svenfuchs/rails-i18n/issues/965

I've PR'd this same fix for upstream: https://github.com/svenfuchs/rails-i18n/pull/972

This works locally on Shopify (update Gemfile to point to `rails-7-sr` and install), but I still want to go through the proper merge process.